### PR TITLE
Fix cart quantity handling

### DIFF
--- a/src/app/pos/page.tsx
+++ b/src/app/pos/page.tsx
@@ -5,21 +5,7 @@ import Cart from "@/components/pos/Cart";
 import CheckoutModal from "@/components/pos/CheckoutModal";
 import Link from "next/link";
 import toast from "react-hot-toast";
-
-// Define types
-interface Product {
-  id: string;
-  name: string;
-  price: number;
-  stock: number;
-  category?: string;
-  image?: string;
-  barcode?: string;
-}
-
-interface CartItem extends Product {
-  qty: number;
-}
+import type { Product, CartItem } from "@/types/pos";
 
 export default function POSPage() {
   // State for managing cart and UI

--- a/src/components/pages/pos.tsx
+++ b/src/components/pages/pos.tsx
@@ -2,12 +2,13 @@ import { useState } from "react";
 import ProductList from "@/components/pos/ProductList";
 import Cart from "@/components/pos/Cart";
 import CheckoutModal from "@/components/pos/CheckoutModal";
+import type { CartItem } from "@/types/pos";
 
 export default function POSPage() {
-  const [cart, setCart] = useState<any[]>([]);
+  const [cart, setCart] = useState<CartItem[]>([]);
   const [modalOpen, setModalOpen] = useState(false);
 
-  const addToCart = (product: any) => {
+  const addToCart = (product: CartItem) => {
     setCart(prev => {
       const idx = prev.findIndex(item => item.id === product.id);
       if (idx !== -1) {
@@ -17,6 +18,12 @@ export default function POSPage() {
       }
       return [...prev, { ...product, qty: 1 }];
     });
+  };
+
+  const updateQuantity = (id: string, qty: number) => {
+    setCart(prev =>
+      prev.map(item => (item.id === id ? { ...item, qty } : item))
+    );
   };
 
   const removeFromCart = (id: string) =>
@@ -30,10 +37,22 @@ export default function POSPage() {
   };
 
   return (
-    <div className="grid md:grid-cols-2 gap-8">
-      <ProductList onAddToCart={addToCart} />
-      <Cart cart={cart} onRemove={removeFromCart} onCheckout={handleCheckout} />
-      <CheckoutModal open={modalOpen} onClose={() => setModalOpen(false)} onConfirm={handleConfirm} cart={cart} />
+    <div className="min-h-screen p-6 bg-gradient-to-br from-slate-50 to-blue-50">
+      <div className="grid md:grid-cols-2 gap-8">
+        <ProductList onAddToCart={addToCart} />
+        <Cart
+          cart={cart}
+          onRemove={removeFromCart}
+          onUpdateQuantity={updateQuantity}
+          onCheckout={handleCheckout}
+        />
+        <CheckoutModal
+          open={modalOpen}
+          onClose={() => setModalOpen(false)}
+          onConfirm={handleConfirm}
+          cart={cart}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/pos/Cart.tsx
+++ b/src/components/pos/Cart.tsx
@@ -1,13 +1,5 @@
 import { formatCurrency } from "@/components/utils/formatter";
-
-interface CartItem {
-  id: string;
-  name: string;
-  price: number;
-  qty: number;
-  category?: string;
-  image?: string;
-}
+import type { CartItem } from "@/types/pos";
 
 interface CartProps {
   cart: CartItem[];

--- a/src/components/pos/CheckoutModal.tsx
+++ b/src/components/pos/CheckoutModal.tsx
@@ -4,13 +4,7 @@ import Modal from "@/components/common/Modal";
 import { Button } from "@/components/common/Button";
 import { formatCurrency } from "@/components/utils/formatter";
 import Receipt from "@/components/pos/Receipt";
-
-interface CartItem {
-  id: string;
-  name: string;
-  price: number;
-  qty: number;
-}
+import type { CartItem } from "@/types/pos";
 
 interface CheckoutModalProps {
   open: boolean;

--- a/src/components/pos/ProductList.tsx
+++ b/src/components/pos/ProductList.tsx
@@ -1,18 +1,7 @@
 import { useState, useEffect } from "react";
 import Image from "next/image";
 import ProductPlaceholder from "@/components/common/ProductPlaceholder";
-
-interface Product {
-  id: string;
-  name: string;
-  price: number;
-  stock: number;
-  category?: string;
-  image?: string;
-  barcode?: string;
-  description?: string;
-  discount?: number;
-}
+import type { Product } from "@/types/pos";
 
 interface ProductListProps {
   onAddToCart: (product: Product) => void;

--- a/src/components/pos/Receipt.tsx
+++ b/src/components/pos/Receipt.tsx
@@ -3,19 +3,13 @@ import { useState } from 'react';
 import { Button } from "@/components/common/Button";
 import { formatCurrency, formatDateTime, convertToThaiText } from "@/components/utils/formatter";
 import { printContent, generateReceiptNumber, getCurrentDateTime } from "@/components/utils/printing";
+import type { CartItem } from "@/types/pos";
 
 interface ReceiptProps {
   cart: CartItem[];
   paymentMethod: 'cash' | 'card' | 'promptpay';
   receivedAmount?: number;
   change?: number;
-}
-
-interface CartItem {
-  id: string;
-  name: string;
-  price: number;
-  qty: number;
 }
 
 export default function Receipt({ cart, paymentMethod, receivedAmount, change }: ReceiptProps) {

--- a/src/components/products/ProductForm.tsx
+++ b/src/components/products/ProductForm.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/common/Button";
+import type { Product } from "@/types/pos";
 
 interface ProductFormData {
   id?: string;
@@ -12,18 +13,6 @@ interface ProductFormData {
   supplier?: string;
 }
 
-interface Product {
-  id: string;
-  name: string;
-  price: number;
-  stock: number;
-  category?: string;
-  barcode?: string;
-  costPrice?: number;
-  supplier?: string;
-  createdAt?: Date;
-  updatedAt?: Date;
-}
 
 interface ProductFormProps {
   onAdd?: (product: ProductFormData) => void;

--- a/src/components/products/ProductTable.tsx
+++ b/src/components/products/ProductTable.tsx
@@ -1,19 +1,7 @@
 import { formatCurrency } from "@/components/utils/formatter";
 import { useState } from "react";
 import { Button } from "@/components/common/Button";
-
-interface Product {
-  id: string;
-  name: string;
-  price: number;
-  stock: number;
-  category?: string;
-  barcode?: string;
-  costPrice?: number;
-  supplier?: string;
-  createdAt?: Date;
-  updatedAt?: Date;
-}
+import type { Product } from "@/types/pos";
 
 interface ProductTableProps {
   products: Product[];

--- a/src/types/pos.ts
+++ b/src/types/pos.ts
@@ -1,0 +1,19 @@
+export interface Product {
+  id: string;
+  name: string;
+  price: number;
+  stock: number;
+  category?: string;
+  image?: string;
+  barcode?: string;
+  description?: string;
+  discount?: number;
+  costPrice?: number;
+  supplier?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface CartItem extends Product {
+  qty: number;
+}


### PR DESCRIPTION
## Summary
- define shared `Product` and `CartItem` interfaces
- use these types across POS components and product management

## Testing
- `npm run lint` *(fails: `next: not found`)*


------
https://chatgpt.com/codex/tasks/task_e_686cc5ca6388832280af4160dec87bf8